### PR TITLE
Dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,51 @@ The options passed to the plugin is an object where:
  - `models` - an object where each key is the exposed model name and each value is the
     path (relative to the current working directory) of where to find the model on disk.
 
+Example usage in a route handler:
+
+```js
+// customer plugin
+
+exports.register = function (server, options, next) {
+
+    server.route({
+        method: 'GET',
+        path: '/customers',
+        config: {
+            validate: {
+                query: {
+                    name: Joi.string().allow('')
+                }
+            }
+        },
+        handler: function (request, reply) {
+
+            var Customer = request.server.plugins['hapi-mongo-models'].Customer;
+            var filter = {};
+
+            if (request.query.name) {
+                filter['name'] = request.query.name;
+            }
+
+            Customer.find(filter, function (err, results) {
+
+                if (err) {
+                    return reply(err);
+                }
+
+                reply(results);
+            });
+        }
+    });
+
+    next();
+};
+
+exports.register.attributes = {
+    name: 'customers'
+};
+```
+
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ var Joi = require('joi');
 var ObjectAssign = require('object-assign');
 var BaseModel = require('hapi-mongo-models').BaseModel;
 
-var Cat = BaseModel.extend({
+var Customer = BaseModel.extend({
     // instance prototype
     constructor: function (attrs) {
 
@@ -54,18 +54,18 @@ var Cat = BaseModel.extend({
     }
 });
 
-Cat._collection = 'cats'; // the mongo collection name
+Customer._collection = 'customers'; // the mongo collection name
 
-Cat.schema = Joi.object().keys({
+Customer.schema = Joi.object().keys({
     name: Joi.string().required()
 });
 
-Cat.staticFunction = function () {
+Customer.staticFunction = function () {
 
     // static class function
 };
 
-module.exports = Cat;
+module.exports = Customer;
 ```
 
 ### Server plugin
@@ -82,8 +82,8 @@ var plugin = {
         },
         autoIndex: false,
         models: {
-            Customers: './path/to/customers',
-            Orders: './path/to/orders'
+            Customer: './path/to/customer',
+            Order: './path/to/order'
         }
     }
 };
@@ -111,8 +111,8 @@ Or include it in your composer manifest.
             },
             "autoIndex": false,
             "models": {
-              "Customers": "./path/to/customers",
-              "Orders": "./path/to/orders"
+              "Customer": "./path/to/customer",
+              "Order": "./path/to/order"
             }
         }
     }
@@ -519,21 +519,15 @@ MongoDB's native `deleteMany` method where:
     - `count` - if the query succeeded, a number indicating how many documents
       were deleted.
 
-
-### Proxied methods
-
-These methods literally call the native driver methods without any
-modification.
-
-#### `ensureIndex(fieldorspec, options, callback)`
+#### `ensureIndex(fieldOrSpec, [options], callback)`
 
 Proxied call to MongoDB's native driver. See:
-http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#ensureindex
+http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#ensureIndex
 
-#### `count([filter], [options], callback)`
+#### `count(query, [options], callback)`
 
 Proxied call to MongoDB's native driver. See:
-http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#count
+http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#count
 
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Node.js is pretty good. We just want a little sugar on top.
 MongoDB's native Node.js driver. It's a real deal ODM with tons of features.
 You should check it out.
 
-We wanted something in between the MongoDB driver and Mongoose. Something more
-light weight. Something where we can interact with collections using simple
-Javascript classes and get document results as instances of these classes.
+We wanted something in between the MongoDB driver and Mongoose. Something light
+weight where we can interact with collections using simple JavaScript classes
+and get document results as instances of these classes.
 
 We're also big fans of [hapijs](http://hapijs.com/) and their object schema
 validation library [joi](https://github.com/hapijs/joi). Joi works really well
 for defining a model's data schema.
 
-It's just Javascript.
+It's just JavaScript.
 
 
 ## Install
@@ -78,7 +78,7 @@ var plugin = {
     options: {
         mongodb: {
           url: 'mongodb://localhost:27017/hapi-mongo-models-test',
-          settings: { ... }
+          options: { ... }
         },
         autoIndex: false,
         models: {
@@ -107,7 +107,7 @@ Or include it in your composer manifest.
         "hapi-mongo-models": {
             "mongodb": {
               "url": "mongodb://localhost:27017/hapi-mongo-models-test",
-              "settings": { ... },
+              "options": { ... },
             },
             "autoIndex": false,
             "models": {
@@ -123,7 +123,7 @@ The options passed to the plugin is an object where:
 
  - `mongodb` - is an object where:
     - `url` - a string representing the connection url for MongoDB.
-    - `settings` - an optional object passed to the MongoDB's native connect function.
+    - `options` - an optional object passed to the MongoDB's native connect function.
  - `autoIndex` - a boolean specifying if the plugin should call `ensureIndex` for each
     model. Defaults to `true`. Typically set to `false` in production environments.
  - `models` - an object where each key is the exposed model name and each value is the
@@ -174,7 +174,7 @@ Connects to a MongoDB server where:
 
  - `config` - an object with the following keys:
     - `url` - the connection string passed to `MongoClient.connect`.
-    - `settings` - an optional object passed to `MongoClient.connect`.
+    - `options` - an optional object passed to `MongoClient.connect`.
  - `callback` - the callback method using the signature `function (err, db)`
     where:
     - `err` - if the connection failed, the error reason, otherwise `null`.
@@ -226,11 +226,11 @@ where:
  - `results` - is the original `results` if any.
  - any remaining arguments to be sent back if present.
 
-#### `pagedFind(query, fields, sort, limit, page, callback)`
+#### `pagedFind(filter, fields, sort, limit, page, callback)`
 
 A helper method to find documents with paginated results where:
 
- - `query` - is a query object, defining the conditions the documents need to
+ - `filter` - is a filter object, defining the conditions the documents need to
     apply.
  - `fields` - indicates which fields should be included in the response
     (default is all). Can be a string with space separated field names.
@@ -243,7 +243,7 @@ A helper method to find documents with paginated results where:
     results)` where:
     - `err` - if the query failed, the error reason, otherwise null.
     - `results` - the results object where:
-        - `data` - an array of results from the query.
+        - `data` - an array of documents from the query as class instances.
         - `pages` - an object where:
             - `current` - a number indicating the current page.
             - `prev` - a number indicating the previous page.
@@ -278,87 +278,217 @@ Returns a MongoDB friendly sort object.
 
 #### `findById(id, [options], callback)`
 
-Finds one document using MongoDB's native `findOne` method where:
+Finds a document by id using MongoDB's native `findOne` method where:
 
  - `id` - is a string value of the `_id` to find. It will be casted to the type
     of `_idClass`.
  - `options` - an options object passed to MongoDB's native `findOne` method.
- - `callback` - the callback method using the signature `function (err, results)`
+ - `callback` - the callback method using the signature `function (err, result)`
     where:
     - `err` - if the query failed, the error reason, otherwise `null`.
-    - `results` - if the query succeeded, the results of the query.
+    - `result` - if the query succeeded, a document as a class instance.
 
 Note: `callback` passes through `resultFactory`.
 
 #### `findByIdAndUpdate(id, update, [options], callback)`
 
-Finds one document using MongoDB's native `findAndModify` method where:
+Finds a document by id, updates it and returns the document using MongoDB's
+native `findOneAndUpdate` method where:
 
  - `id` - is a string value of the `_id` to find. It will be casted to the type
-    of `_idClass`.
+   of `_idClass`.
  - `update` - an object containing the fields/values to be updated.
  - `options` - an optional options object passed to MongoDB's native
-    `findAndModify` method.
- - `callback` - the callback method using the signature `function (err, results)`
-    where:
+   `findAndModify` method. Defaults to `{ returnOriginal: false }`.
+ - `callback` - the callback method using the signature `function (err, result)`
+   where:
     - `err` - if the query failed, the error reason, otherwise `null`.
-    - `results` - if the query succeeded, the results of the query.
+    - `result` - if the query succeeded, a document as a class instance.
 
 
 Note: `callback` passes through `resultFactory`.
 
-#### `findByIdAndRemove(id, callback)`
+#### `findByIdAndDelete(id, callback)`
 
-Removes one document using MongoDB's native `remove` method where:
+Finds a document by id, deletes it and returns the document using MongoDB's
+native `findOneAndDelete` method where:
 
  - `id` - is a string value of the `_id` to find. It will be casted to the type
-    of `_idClass`.
- - `callback` - the callback method using the signature `function (err)`
-    where:
+   of `_idClass`.
+ - `callback` - the callback method using the signature `function (err, result)`
+   where:
     - `err` - if the query failed, the error reason, otherwise `null`.
+    - `result` - if the query succeeded, a document as a class instance.
+
+#### `find(filter, [options], callback)`
+
+Returns an array of documents using MongoDB's native `find` method where:
+
+ - `filter` - a filter object used to select the documents.
+ - `options` - an options object passed to MongoDB's native `find` method.
+ - `callback` - the callback method using the signature `function (err, results)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `results` - if the query succeeded, an array of documents as class
+      instances.
+
+Note: `callback` passes through `resultFactory`.
+
+#### `findOne(filter, [options], callback)`
+
+Returns a document using MongoDB's native `findOne` method where:
+
+ - `filter` - a filter object used to select the document.
+ - `options` - an options object passed to MongoDB's native `findOne` method.
+ - `callback` - the callback method using the signature `function (err, result)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `result` - if the query succeeded, a document as a class instance.
+
+Note: `callback` passes through `resultFactory`.
+
+#### `findOneAndUpdate(filter, [options], callback)`
+
+Finds a document, updates it and returns the new document using MongoDB's
+native `findOneAndUpdate` method where:
+
+ - `filter` - a filter object used to select the document to update.
+ - `options` - an options object passed to MongoDB's native `findOneAndUpdate`
+   method. Defaults to `{ returnOriginal: false }`.
+ - `callback` - the callback method using the signature `function (err, result)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `result` - if the query succeeded, a document as a class instance.
+
+Note: `callback` passes through `resultFactory`.
+
+#### `findOneAndDelete(filter, [options], callback)`
+
+Finds a document, deletes it and returns the document using MongoDB's native
+`findOneAndDelete` method where:
+
+ - `filter` - a filter object used to select the document to delete.
+ - `options` - an options object passed to MongoDB's native `findOneAndDelete`
+   method.
+ - `callback` - the callback method using the signature `function (err, count)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `count` - if the query succeeded, a number indicating how many documents
+      were deleted.
+
+#### `insertOne(doc, [options], callback)`
+
+Inserts a document and returns the new document using MongoDB's native
+`insertOne` method where:
+
+ - `doc` - a document object to insert.
+ - `options` - an options object passed to MongoDB's native `insertOne` method.
+ - `callback` - the callback method using the signature `function (err, results)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `results` - if the query succeeded, an array of documents as a class
+      instances.
+
+Note: `callback` passes through `resultFactory`.
+
+#### `insertMany(docs, [options], callback)`
+
+Inserts multiple documents and returns the new documents using MongoDB's native
+`insertMany` method where:
+
+ - `docs` - an array of document objects to insert.
+ - `options` - an options object passed to MongoDB's native `insertMany` method.
+ - `callback` - the callback method using the signature `function (err, results)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `results` - if the query succeeded, an array of documents as a class
+      instances.
+
+Note: `callback` passes through `resultFactory`.
+
+#### `updateOne(filter, update, [options], callback)`
+
+Updates a document and returns the count of modified documents using MongoDB's
+native `updateOne` method where:
+
+ - `filter` - a filter object used to select the document to update.
+ - `update` - the update operations object.
+ - `options` - an options object passed to MongoDB's native `updateOne` method.
+ - `callback` - the callback method using the signature `function (err, count)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `count` - if the query succeeded, a number indicating how many documents
+      were modified.
+
+#### `updateMany(filter, update, [options], callback)`
+
+Updates multiple documents and returns the count of modified documents using
+MongoDB's native `updateMany` method where:
+
+ - `filter` - a filter object used to select the documents to update.
+ - `update` - the update operations object.
+ - `options` - an options object passed to MongoDB's native `updateOne` method.
+ - `callback` - the callback method using the signature `function (err, count)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `count` - if the query succeeded, a number indicating how many documents
+      were modified.
+
+#### `replaceOne(filter, doc, [options], callback)`
+
+Replaces a document and returns the count of modified documents using
+MongoDB's native `replaceOne` method where:
+
+ - `filter` - a filter object used to select the document to replace.
+ - `doc` - the document that replaces the matching document.
+ - `options` - an options object passed to MongoDB's native `replaceOne` method.
+ - `callback` - the callback method using the signature `function (err, count)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `count` - if the query succeeded, a number indicating how many documents
+      were modified.
+
+#### `deleteOne(filter, [options], callback)`
+
+Deletes a document and returns the count of deleted documents using
+MongoDB's native `deleteOne` method where:
+
+ - `filter` - a filter object used to select the document to remove.
+ - `options` - an options object passed to MongoDB's native `deleteOne` method.
+ - `callback` - the callback method using the signature `function (err, count)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `count` - if the query succeeded, a number indicating how many documents
+      were deleted.
+
+#### `deleteMany(filter, [options], callback)`
+
+Deletes multiple documents and returns the count of deleted documents using
+MongoDB's native `deleteMany` method where:
+
+ - `filter` - a filter object used to select the documents to remove.
+ - `options` - an options object passed to MongoDB's native `deleteMany` method.
+ - `callback` - the callback method using the signature `function (err, count)`
+   where:
+    - `err` - if the query failed, the error reason, otherwise `null`.
+    - `count` - if the query succeeded, a number indicating how many documents
+      were deleted.
+
 
 ### Proxied methods
+
+These methods literally call the native driver methods without any
+modification.
 
 #### `ensureIndex(fieldorspec, options, callback)`
 
 Proxied call to MongoDB's native driver. See:
 http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#ensureindex
 
-#### `count([query], [options], callback)`
+#### `count([filter], [options], callback)`
 
 Proxied call to MongoDB's native driver. See:
 http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#count
-
-#### `find(query, [options], callback)`
-
-Proxied call to MongoDB's native driver. See:
-http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#find
-
-Note: `callback` passes through `resultFactory`.
-
-#### `findOne(query, [options], callback)`
-
-Proxied call to MongoDB's native driver. See:
-http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#findone
-
-Note: `callback` passes through `resultFactory`.
-
-#### `insert(docs, [options], callback)`
-
-Proxied call to MongoDB's native driver. See:
-http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#insert
-
-Note: `callback` passes through `resultFactory`.
-
-#### `update(selector, document, [options], [callback])`
-
-Proxied call to MongoDB's native driver. See:
-http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#update
-
-#### `remove([selector], [options], [callback])`
-
-Proxied call to MongoDB's native driver. See:
-http://mongodb.github.io/node-mongodb-native/api-generated/collection.html#remove
 
 
 ## Examples

--- a/lib/base-model.js
+++ b/lib/base-model.js
@@ -13,7 +13,7 @@ BaseModel.ObjectId = BaseModel.ObjectID = Mongodb.ObjectID;
 
 BaseModel.connect = function (config, callback) {
 
-    Mongodb.MongoClient.connect(config.url, config.settings, function (err, db) {
+    Mongodb.MongoClient.connect(config.url, config.options, function (err, db) {
 
         if (err) {
             return callback(err);

--- a/lib/base-model.js
+++ b/lib/base-model.js
@@ -54,7 +54,7 @@ BaseModel.ensureIndexes = function (callback) {
 BaseModel.ensureIndex = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 
@@ -78,7 +78,7 @@ BaseModel.prototype.validate = function (callback) {
 BaseModel.resultFactory = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 
@@ -224,7 +224,7 @@ BaseModel.sortAdapter = function (sorts) {
 BaseModel.count = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 
@@ -236,7 +236,7 @@ BaseModel.count = function () {
 BaseModel.find = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 
@@ -250,7 +250,7 @@ BaseModel.find = function () {
 BaseModel.findOne = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 
@@ -265,7 +265,7 @@ BaseModel.findOne = function () {
 BaseModel.findById = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 
@@ -290,7 +290,7 @@ BaseModel.findById = function () {
 BaseModel.findByIdAndUpdate = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 
@@ -331,7 +331,7 @@ BaseModel.findByIdAndRemove = function (id, callback) {
 BaseModel.insert = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 
@@ -346,7 +346,7 @@ BaseModel.insert = function () {
 BaseModel.update = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 
@@ -358,7 +358,7 @@ BaseModel.update = function () {
 BaseModel.remove = function () {
 
     var args = new Array(arguments.length);
-    for (var i = 0 ; i < args.length ; ++i) {
+    for (var i = 0; i < args.length; ++i) {
         args[i] = arguments[i];
     }
 

--- a/lib/base-model.js
+++ b/lib/base-model.js
@@ -102,7 +102,20 @@ BaseModel.resultFactory = function () {
     }
 
     if (Object.prototype.toString.call(result) === '[object Object]') {
-        result = new this(result);
+        if (result.hasOwnProperty('value') && !result.hasOwnProperty('_id')) {
+            result = new this(result.value);
+        }
+        else if (result.hasOwnProperty('ops')) {
+            result.ops.forEach(function (item, index) {
+
+                result.ops[index] = new self(item);
+            });
+
+            result = result.ops;
+        }
+        else if (result.hasOwnProperty('_id')) {
+            result = new this(result);
+        }
     }
 
     args.unshift(result);
@@ -111,7 +124,7 @@ BaseModel.resultFactory = function () {
 };
 
 
-BaseModel.pagedFind = function (query, fields, sort, limit, page, callback) {
+BaseModel.pagedFind = function (filter, fields, sort, limit, page, callback) {
 
     var self = this;
     var output = {
@@ -138,7 +151,7 @@ BaseModel.pagedFind = function (query, fields, sort, limit, page, callback) {
     Async.auto({
         count: function (done) {
 
-            self.count(query, done);
+            self.count(filter, done);
         },
         find: function (done) {
 
@@ -148,7 +161,7 @@ BaseModel.pagedFind = function (query, fields, sort, limit, page, callback) {
                 sort: sort
             };
 
-            self.find(query, fields, options, done);
+            self.find(filter, fields, options, done);
         }
     }, function (err, results) {
 
@@ -262,6 +275,65 @@ BaseModel.findOne = function () {
 };
 
 
+BaseModel.findOneAndUpdate = function () {
+
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+        args[i] = arguments[i];
+    }
+
+    var collection = BaseModel.db.collection(this._collection);
+    var callback = this.resultFactory.bind(this, args.pop());
+    var filter = args.shift();
+    var doc = args.shift();
+    var options = Hoek.applyToDefaults({ returnOriginal: false }, args.pop() || {});
+
+    args.push(filter);
+    args.push(doc);
+    args.push(options);
+    args.push(callback);
+
+    collection.findOneAndUpdate.apply(collection, args);
+};
+
+
+BaseModel.findOneAndDelete = function () {
+
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+        args[i] = arguments[i];
+    }
+
+    var collection = BaseModel.db.collection(this._collection);
+    var callback = this.resultFactory.bind(this, args.pop());
+
+    args.push(callback);
+    collection.findOneAndDelete.apply(collection, args);
+};
+
+
+BaseModel.findOneAndReplace = function () {
+
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+        args[i] = arguments[i];
+    }
+
+    var collection = BaseModel.db.collection(this._collection);
+    var callback = this.resultFactory.bind(this, args.pop());
+    var filter = args.shift();
+    var doc = args.shift();
+    var options = Hoek.applyToDefaults({ returnOriginal: false }, args.pop() || {});
+
+    args.push(filter);
+    args.push(doc);
+    args.push(options);
+    args.push(callback);
+
+    collection.findOneAndReplace.apply(collection, args);
+};
+
+
 BaseModel.findById = function () {
 
     var args = new Array(arguments.length);
@@ -272,16 +344,16 @@ BaseModel.findById = function () {
     var collection = BaseModel.db.collection(this._collection);
     var id = args.shift();
     var callback = this.resultFactory.bind(this, args.pop());
-    var query;
+    var filter;
 
     try {
-        query = { _id: this._idClass(id) };
+        filter = { _id: this._idClass(id) };
     }
     catch (exception) {
         return callback(exception);
     }
 
-    args.unshift(query);
+    args.unshift(filter);
     args.push(callback);
     collection.findOne.apply(collection, args);
 };
@@ -298,37 +370,45 @@ BaseModel.findByIdAndUpdate = function () {
     var id = args.shift();
     var update = args.shift();
     var callback = this.resultFactory.bind(this, args.pop());
-    var options = Hoek.applyToDefaults({ new: true }, args.pop() || {});
-    var query;
+    var options = Hoek.applyToDefaults({ returnOriginal: false }, args.pop() || {});
+    var filter;
 
     try {
-        query = { _id: this._idClass(id) };
+        filter = { _id: this._idClass(id) };
     }
     catch (exception) {
         return callback(exception);
     }
 
-    collection.findAndModify(query, undefined, update, options, callback);
+    collection.findOneAndUpdate(filter, update, options, callback);
 };
 
 
-BaseModel.findByIdAndRemove = function (id, callback) {
+BaseModel.findByIdAndDelete = function () {
+
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+        args[i] = arguments[i];
+    }
 
     var collection = BaseModel.db.collection(this._collection);
-    var query;
+    var id = args.shift();
+    var callback = this.resultFactory.bind(this, args.pop());
+    var options = Hoek.applyToDefaults({}, args.pop() || {});
+    var filter;
 
     try {
-        query = { _id: this._idClass(id) };
+        filter = { _id: this._idClass(id) };
     }
     catch (exception) {
         return callback(exception);
     }
 
-    collection.remove(query, callback);
+    collection.findOneAndDelete(filter, options, callback);
 };
 
 
-BaseModel.insert = function () {
+BaseModel.insertOne = function () {
 
     var args = new Array(arguments.length);
     for (var i = 0; i < args.length; ++i) {
@@ -339,11 +419,11 @@ BaseModel.insert = function () {
     var callback = this.resultFactory.bind(this, args.pop());
 
     args.push(callback);
-    collection.insert.apply(collection, args);
+    collection.insertOne.apply(collection, args);
 };
 
 
-BaseModel.update = function () {
+BaseModel.insertMany = function () {
 
     var args = new Array(arguments.length);
     for (var i = 0; i < args.length; ++i) {
@@ -351,11 +431,14 @@ BaseModel.update = function () {
     }
 
     var collection = BaseModel.db.collection(this._collection);
-    collection.update.apply(collection, args);
+    var callback = this.resultFactory.bind(this, args.pop());
+
+    args.push(callback);
+    collection.insertMany.apply(collection, args);
 };
 
 
-BaseModel.remove = function () {
+BaseModel.updateOne = function () {
 
     var args = new Array(arguments.length);
     for (var i = 0; i < args.length; ++i) {
@@ -363,7 +446,128 @@ BaseModel.remove = function () {
     }
 
     var collection = BaseModel.db.collection(this._collection);
-    collection.remove.apply(collection, args);
+    var filter = args.shift();
+    var update = args.shift();
+    var callback = args.pop();
+    var options = Hoek.applyToDefaults({}, args.pop() || {});
+
+    args.push(filter);
+    args.push(update);
+    args.push(options);
+    args.push(function (err, results) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        callback(null, results.modifiedCount);
+    });
+
+    collection.updateOne.apply(collection, args);
+};
+
+
+BaseModel.updateMany = function () {
+
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+        args[i] = arguments[i];
+    }
+
+    var collection = BaseModel.db.collection(this._collection);
+    var filter = args.shift();
+    var update = args.shift();
+    var callback = args.pop();
+    var options = Hoek.applyToDefaults({}, args.pop() || {});
+
+    args.push(filter);
+    args.push(update);
+    args.push(options);
+    args.push(function (err, results) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        callback(null, results.modifiedCount);
+    });
+
+    collection.updateMany.apply(collection, args);
+};
+
+
+BaseModel.replaceOne = function () {
+
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+        args[i] = arguments[i];
+    }
+
+    var collection = BaseModel.db.collection(this._collection);
+    var filter = args.shift();
+    var doc = args.shift();
+    var callback = args.pop();
+    var options = Hoek.applyToDefaults({}, args.pop() || {});
+
+    args.push(filter);
+    args.push(doc);
+    args.push(options);
+    args.push(function (err, results) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        callback(null, results.modifiedCount);
+    });
+
+    collection.replaceOne.apply(collection, args);
+};
+
+
+BaseModel.deleteOne = function () {
+
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+        args[i] = arguments[i];
+    }
+
+    var collection = BaseModel.db.collection(this._collection);
+    var callback = args.pop();
+
+    args.push(function (err, results) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        callback(null, results.deletedCount);
+    });
+
+    collection.deleteOne.apply(collection, args);
+};
+
+
+BaseModel.deleteMany = function () {
+
+    var args = new Array(arguments.length);
+    for (var i = 0; i < args.length; ++i) {
+        args[i] = arguments[i];
+    }
+
+    var collection = BaseModel.db.collection(this._collection);
+    var callback = args.pop();
+
+    args.push(function (err, results) {
+
+        if (err) {
+            return callback(err);
+        }
+
+        callback(null, results.deletedCount);
+    });
+
+    collection.deleteMany.apply(collection, args);
 };
 
 

--- a/lib/base-model.js
+++ b/lib/base-model.js
@@ -103,7 +103,12 @@ BaseModel.resultFactory = function () {
 
     if (Object.prototype.toString.call(result) === '[object Object]') {
         if (result.hasOwnProperty('value') && !result.hasOwnProperty('_id')) {
-            result = new this(result.value);
+            if (result.value) {
+                result = new this(result.value);
+            }
+            else {
+                result = undefined;
+            }
         }
         else if (result.hasOwnProperty('ops')) {
             result.ops.forEach(function (item, index) {

--- a/package.json
+++ b/package.json
@@ -27,20 +27,20 @@
   },
   "homepage": "https://github.com/jedireza/hapi-mongo-models",
   "devDependencies": {
-    "code": "^1.2.1",
-    "hapi": "^8.0.0",
-    "lab": "^5.1.0",
-    "mongodb": "^1.4.23",
-    "proxyquire": "^1.3.0"
+    "code": "^1.x.x",
+    "hapi": "^8.x.x",
+    "lab": "^5.x.x",
+    "mongodb": "^2.x.x",
+    "proxyquire": "^1.x.x"
   },
   "peerDependencies": {
-    "mongodb": "^1.4.23"
+    "mongodb": "^2.x.x"
   },
   "dependencies": {
-    "ampersand-class-extend": "^1.0.1",
-    "async": "^0.9.0",
-    "hoek": "^2.10.0",
-    "joi": "^6.0.3",
-    "object-assign": "^2.0.0"
+    "ampersand-class-extend": "^1.x.x",
+    "async": "^0.9.x",
+    "hoek": "^2.x.x",
+    "joi": "^6.x.x",
+    "object-assign": "^2.x.x"
   }
 }

--- a/test/config.js
+++ b/test/config.js
@@ -1,6 +1,6 @@
 module.exports = {
     mongodb: {
         url: 'mongodb://localhost:27017/hapi-mongo-models-test',
-        settings: {}
+        options: {}
     }
 };

--- a/test/lib/base-model.js
+++ b/test/lib/base-model.js
@@ -25,9 +25,9 @@ lab.experiment('BaseModel DB Connection', function () {
             Code.expect(err).to.not.exist();
             Code.expect(db).to.be.an.object();
 
-            Code.expect(BaseModel.db.openCalled).to.equal(true);
+            Code.expect(BaseModel.db.serverConfig.isConnected()).to.equal(true);
             BaseModel.disconnect();
-            Code.expect(BaseModel.db.openCalled).to.equal(false);
+            Code.expect(BaseModel.db.serverConfig.isConnected()).to.equal(false);
 
             done();
         });
@@ -41,7 +41,7 @@ lab.experiment('BaseModel DB Connection', function () {
         stub.mongodb.MongoClient = {
             connect: function (url, settings, callback) {
 
-                callback(Error('mongodb is gone'));
+                callback(new Error('mongodb is gone'));
             }
         };
 
@@ -103,14 +103,23 @@ lab.experiment('BaseModel Validation', function () {
 
 lab.experiment('BaseModel Result Factory', function () {
 
-    lab.test('it returns early when an error is present', function (done) {
+    var SubModel;
 
-        var SubModel = BaseModel.extend({
+
+    lab.before(function (done) {
+
+        SubModel = BaseModel.extend({
             constructor: function (attrs) {
 
                 ObjectAssign(this, attrs);
             }
         });
+
+        done();
+    });
+
+
+    lab.test('it returns early when an error is present', function (done) {
 
         var callback = function (err, result) {
 
@@ -120,18 +129,11 @@ lab.experiment('BaseModel Result Factory', function () {
             done();
         };
 
-        SubModel.resultFactory(callback, Error('it went boom'), undefined);
+        SubModel.resultFactory(callback, new Error('it went boom'), undefined);
     });
 
 
-    lab.test('it returns an instance for a single result', function (done) {
-
-        var SubModel = BaseModel.extend({
-            constructor: function (attrs) {
-
-                ObjectAssign(this, attrs);
-            }
-        });
+    lab.test('it returns an instance for a single document result', function (done) {
 
         var callback = function (err, result) {
 
@@ -140,23 +142,21 @@ lab.experiment('BaseModel Result Factory', function () {
 
             done();
         };
+        var document = {
+            _id: '54321',
+            name: 'Stimpy'
+        };
 
-        SubModel.resultFactory(callback, undefined, {name: 'Stimpy'});
+        SubModel.resultFactory(callback, undefined, document);
     });
 
 
-    lab.test('it returns an array of instances for a result array', function (done) {
-
-        var SubModel = BaseModel.extend({
-            constructor: function (attrs) {
-
-                ObjectAssign(this, attrs);
-            }
-        });
+    lab.test('it returns an array of instances for a `WriteOpResultObject`', function (done) {
 
         var callback = function (err, results) {
 
             Code.expect(err).to.not.exist();
+            Code.expect(results).to.be.an.array();
 
             results.forEach(function (result) {
 
@@ -165,8 +165,30 @@ lab.experiment('BaseModel Result Factory', function () {
 
             done();
         };
+        var results = {
+            ops: [
+                { name: 'Ren' },
+                { name: 'Stimpy' }
+            ]
+        };
 
-        SubModel.resultFactory(callback, undefined, [{name: 'Ren'}, {name: 'Stimpy'}]);
+        SubModel.resultFactory(callback, undefined, results);
+    });
+
+
+    lab.test('it does not convert an object into an instance without an _id property', function (done) {
+
+        var callback = function (err, result) {
+
+            Code.expect(err).to.not.exist();
+            Code.expect(result).to.be.an.object();
+            Code.expect(result).to.not.be.an.instanceOf(SubModel);
+
+            done();
+        };
+        var document = { name: 'Ren' };
+
+        SubModel.resultFactory(callback, undefined, document);
     });
 });
 
@@ -197,7 +219,6 @@ lab.experiment('BaseModel Indexes', function () {
     lab.after(function (done) {
 
         BaseModel.disconnect();
-
         done();
     });
 
@@ -253,7 +274,6 @@ lab.experiment('BaseModel Indexes', function () {
         ];
 
         Code.expect(SubModel.ensureIndexes()).to.equal(undefined);
-
         done();
     });
 });
@@ -315,11 +335,16 @@ lab.experiment('BaseModel Paged Find', function () {
     });
 
 
+    lab.after(function (done) {
+
+        BaseModel.disconnect();
+        done();
+    });
+
+
     lab.afterEach(function (done) {
 
-        SubModel.remove({}, function (err, result) {
-
-            BaseModel.disconnect();
+        SubModel.deleteMany({}, function (err, result) {
 
             done();
         });
@@ -329,17 +354,17 @@ lab.experiment('BaseModel Paged Find', function () {
     lab.test('it returns early when an error occurs', function (done) {
 
         var realCount = SubModel.count;
-        SubModel.count = function (query, callback) {
-            callback(Error('count failed'));
+        SubModel.count = function (filter, callback) {
+            callback(new Error('count failed'));
         };
 
-        var query = {};
+        var filter = {};
         var fields;
         var limit = 10;
         var page = 1;
         var sort = { _id: -1 };
 
-        SubModel.pagedFind(query, fields, sort, limit, page, function (err, results) {
+        SubModel.pagedFind(filter, fields, sort, limit, page, function (err, results) {
 
             Code.expect(err).to.be.an.object();
             Code.expect(results).to.not.exist();
@@ -356,19 +381,23 @@ lab.experiment('BaseModel Paged Find', function () {
         Async.auto({
             setup: function (cb) {
 
-                var testData = [{name: 'Ren'}, {name: 'Stimpy'}, {name: 'Yak'}];
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
 
-                SubModel.insert(testData, cb);
+                SubModel.insertMany(testDocs, cb);
             }
         }, function (err, results) {
 
-            var query = {};
+            var filter = {};
             var fields;
             var limit = 10;
             var page = 1;
             var sort = { _id: -1 };
 
-            SubModel.pagedFind(query, fields, sort, limit, page, function (err, results) {
+            SubModel.pagedFind(filter, fields, sort, limit, page, function (err, results) {
 
                 Code.expect(err).to.not.exist();
                 Code.expect(results).to.be.an.object();
@@ -384,19 +413,23 @@ lab.experiment('BaseModel Paged Find', function () {
         Async.auto({
             setup: function (cb) {
 
-                var testData = [{name: 'Ren'}, {name: 'Stimpy'}, {name: 'Yak'}];
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
 
-                SubModel.insert(testData, cb);
+                SubModel.insertMany(testDocs, cb);
             }
         }, function (err, results) {
 
-            var query = {};
+            var filter = {};
             var fields;
             var limit = 2;
             var page = 1;
             var sort = { _id: -1 };
 
-            SubModel.pagedFind(query, fields, sort, limit, page, function (err, results) {
+            SubModel.pagedFind(filter, fields, sort, limit, page, function (err, results) {
 
                 Code.expect(err).to.not.exist();
                 Code.expect(results).to.be.an.object();
@@ -412,23 +445,23 @@ lab.experiment('BaseModel Paged Find', function () {
         Async.auto({
             setup: function (cb) {
 
-                var testData = [
-                    {name: 'Ren'},
-                    {name: 'Stimpy'},
-                    {name: 'Yak'}
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
                 ];
 
-                SubModel.insert(testData, cb);
+                SubModel.insertMany(testDocs, cb);
             }
         }, function (err, results) {
 
-            var query = { 'role.special': { $exists: true } };
+            var filter = { 'role.special': { $exists: true } };
             var fields;
             var limit = 2;
             var page = 1;
             var sort = { _id: -1 };
 
-            SubModel.pagedFind(query, fields, sort, limit, page, function (err, results) {
+            SubModel.pagedFind(filter, fields, sort, limit, page, function (err, results) {
 
                 Code.expect(err).to.not.exist();
                 Code.expect(results).to.be.an.object();
@@ -442,7 +475,7 @@ lab.experiment('BaseModel Paged Find', function () {
 
 lab.experiment('BaseModel Proxied Methods', function () {
 
-    var SubModel, liveTestData;
+    var SubModel;
 
 
     lab.before(function (done) {
@@ -466,22 +499,43 @@ lab.experiment('BaseModel Proxied Methods', function () {
     lab.after(function (done) {
 
         BaseModel.disconnect();
-
         done();
+    });
+
+
+    lab.afterEach(function (done) {
+
+        SubModel.deleteMany({}, function (err, result) {
+
+            done();
+        });
     });
 
 
     lab.test('it inserts data and returns the results', function (done) {
 
-        var testData = [
-            {name: 'Ren'},
-            {name: 'Stimpy'},
-            {name: 'Yak'}
+        var testDocs = [
+            { name: 'Ren' },
+            { name: 'Stimpy' },
+            { name: 'Yak' }
         ];
 
-        SubModel.insert(testData, function (err, results) {
+        SubModel.insertMany(testDocs, function (err, results) {
 
-            liveTestData = results;
+            Code.expect(err).to.not.exist();
+            Code.expect(results).to.be.an.array();
+            Code.expect(results.length).to.equal(3);
+
+            done(err);
+        });
+    });
+
+
+    lab.test('it inserts one document and returns the result', function (done) {
+
+        var testDoc = { name: 'Horse' };
+
+        SubModel.insertOne(testDoc, function (err, results) {
 
             Code.expect(err).to.not.exist();
             Code.expect(results).to.be.an.array();
@@ -491,75 +545,335 @@ lab.experiment('BaseModel Proxied Methods', function () {
     });
 
 
-    lab.test('it updates a document and returns the results', function (done) {
+    lab.test('it inserts many documents and returns the results', function (done) {
 
-        var query = {
-            _id: liveTestData[0]._id
-        };
-        var update = {
-            $set: { isCool: true }
-        };
+        var testDocs = [
+            { name: 'Toast' },
+            { name: 'Space' }
+        ];
 
-        SubModel.update(query, update, function (err, count, status) {
+        SubModel.insertMany(testDocs, function (err, results) {
 
             Code.expect(err).to.not.exist();
-            Code.expect(count).to.be.a.number();
-            Code.expect(status).to.be.an.object();
+            Code.expect(results).to.be.an.array();
+            Code.expect(results.length).to.equal(2);
 
             done(err);
         });
     });
 
 
+    lab.test('it updates a document and returns the results', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
+
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, function (err, results) {
+
+            var filter = {
+                _id: results.setup[0]._id
+            };
+            var update = {
+                $set: { isCool: true }
+            };
+
+            SubModel.updateOne(filter, update, function (err, count) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(1);
+
+                done(err);
+            });
+        });
+    });
+
+
+    lab.test('it updates a document and returns the results (with options)', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
+
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, function (err, results) {
+
+            var filter = {
+                _id: results.setup[0]._id
+            };
+            var update = {
+                $set: { isCool: true }
+            };
+            var options = { upsert: true };
+
+            SubModel.updateOne(filter, update, options, function (err, count) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(1);
+
+                done(err);
+            });
+        });
+    });
+
+
+    lab.test('it returns an error when updateOne fails', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var realCollection = BaseModel.db.collection;
+            BaseModel.db.collection = function () {
+
+                return {
+                    updateOne: function (filter, update, options, callback) {
+
+                        callback(new Error('Whoops!'));
+                    }
+                };
+            };
+
+            var filter = {};
+            var update = { $set: { isCool: true } };
+
+            SubModel.updateOne(filter, update, function (err, count) {
+
+                Code.expect(err).to.exist();
+                Code.expect(count).to.not.exist();
+
+                BaseModel.db.collection = realCollection;
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it updates many documents and returns the results', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
+
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, function (err, results) {
+
+            var filter = {};
+            var update = { $set: { isCool: true } };
+
+            SubModel.updateMany(filter, update, function (err, count) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(3);
+
+                done(err);
+            });
+        });
+    });
+
+
+    lab.test('it updates many documents and returns the results (with options)', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
+
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, function (err, results) {
+
+            var filter = {};
+            var update = { $set: { isCool: true } };
+            var options = { upsert: true };
+
+            SubModel.updateMany(filter, update, options, function (err, count) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(3);
+
+                done(err);
+            });
+        });
+    });
+
+
+    lab.test('it returns an error when updateMany fails', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var realCollection = BaseModel.db.collection;
+            BaseModel.db.collection = function () {
+
+                return {
+                    updateMany: function (filter, update, options, callback) {
+
+                        callback(new Error('Whoops!'));
+                    }
+                };
+            };
+
+            var filter = {};
+            var update = { $set: { isCool: true } };
+
+            SubModel.updateMany(filter, update, function (err, count) {
+
+                Code.expect(err).to.exist();
+                Code.expect(count).to.not.exist();
+
+                BaseModel.db.collection = realCollection;
+                done();
+            });
+        });
+    });
+
+
     lab.test('it returns a collection count', function (done) {
 
-        SubModel.count({}, function (err, result) {
+        Async.auto({
+            setup: function (cb) {
 
-            Code.expect(err).to.not.exist();
-            Code.expect(result).to.be.a.number();
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
 
-            done();
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, function (err, results) {
+
+            SubModel.count({}, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.a.number();
+                Code.expect(result).to.equal(3);
+
+                done();
+            });
         });
     });
 
 
     lab.test('it returns a result array', function (done) {
 
-        SubModel.find({}, function (err, result) {
+        Async.auto({
+            setup: function (cb) {
 
-            Code.expect(err).to.not.exist();
-            Code.expect(result).to.be.an.array();
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' },
+                    { name: 'Yak' }
+                ];
 
-            done();
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, function (err, results) {
+
+            SubModel.find({}, function (err, results) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(results).to.be.an.array();
+
+                results.forEach(function (result) {
+
+                    Code.expect(result).to.be.an.instanceOf(SubModel);
+                });
+
+                done();
+            });
         });
     });
 
 
     lab.test('it returns a single result', function (done) {
 
-        SubModel.findOne({}, function (err, result) {
+        Async.auto({
+            setup: function (cb) {
 
-            Code.expect(err).to.not.exist();
-            Code.expect(result).to.be.an.object();
+                var testDoc = { name: 'Ren' };
 
-            done();
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            SubModel.findOne({}, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
         });
     });
 
 
     lab.test('it returns a single result via id', function (done) {
 
-        SubModel.findById(liveTestData[0]._id, function (err, result) {
+        Async.auto({
+            setup: function (cb) {
 
-            Code.expect(err).to.not.exist();
-            Code.expect(result).to.be.an.object();
+                var testDoc = { name: 'Ren' };
 
-            done();
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var id = results.setup[0]._id;
+
+            SubModel.findById(id, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
         });
     });
 
 
-    lab.test('it catches the exception when id casting fails during findById', function (done) {
+    lab.test('it returns and error when id casting fails during findById', function (done) {
 
         SubModel.findById('NOTVALIDOBJECTID', function (err, result) {
 
@@ -569,21 +883,33 @@ lab.experiment('BaseModel Proxied Methods', function () {
     });
 
 
-    lab.test('it updates a single document via id', function (done) {
+    lab.test('it updates a single document via findByIdAndUpdate', function (done) {
 
-        var document = { name: 'New Name' };
+        Async.auto({
+            setup: function (cb) {
 
-        SubModel.findByIdAndUpdate(liveTestData[0]._id, document, function (err, result) {
+                var testDoc = { name: 'Ren' };
 
-            Code.expect(err).to.not.exist();
-            Code.expect(result).to.be.an.object();
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
 
-            done();
+            var id = results.setup[0]._id;
+            var update = { name: 'New Name' };
+
+            SubModel.findByIdAndUpdate(id, update, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
         });
     });
 
 
-    lab.test('it catches the exception when id casting fails during findByIdAndUpdate', function (done) {
+    lab.test('it returns an error when casting fails during findByIdAndUpdate', function (done) {
 
         SubModel.findByIdAndUpdate('NOTVALIDOBJECTID', {}, function (err, result) {
 
@@ -595,35 +921,310 @@ lab.experiment('BaseModel Proxied Methods', function () {
 
     lab.test('it updates a single document via id (with options)', function (done) {
 
-        var document = { name: 'New Name' };
-        var options = { upsert: true };
+        Async.auto({
+            setup: function (cb) {
 
-        SubModel.findByIdAndUpdate(liveTestData[0]._id, document, options, function (err, result) {
+                var testDoc = { name: 'Ren' };
 
-            Code.expect(err).to.not.exist();
-            Code.expect(result).to.be.an.object();
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
 
-            done();
+            var id = results.setup[0]._id;
+            var update = { name: 'New Name' };
+            var options = { returnOriginal: false };
+
+            SubModel.findByIdAndUpdate(id, update, options, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
         });
     });
 
 
-    lab.test('it removes a single document via id', function (done) {
+    lab.test('it updates a single document via findOneAndUpdate', function (done) {
 
-        SubModel.findByIdAndRemove(liveTestData[0]._id, function (err, result) {
+        Async.auto({
+            setup: function (cb) {
 
-            Code.expect(err).to.not.exist();
-            Code.expect(result).to.be.a.number();
-            Code.expect(result).to.equal(1);
+                var testDoc = { name: 'Ren' };
 
-            done();
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var filter = { name: 'Ren' };
+            var update = { name: 'New Name' };
+
+            SubModel.findOneAndUpdate(filter, update, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
         });
     });
 
 
-    lab.test('it catches the exception when id casting fails during findByIdAndRemove', function (done) {
+    lab.test('it updates a single document via findOneAndUpdate (with options)', function (done) {
 
-        SubModel.findByIdAndRemove('NOTVALIDOBJECTID', function (err, result) {
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var filter = { name: 'Ren' };
+            var update = { name: 'New Name' };
+            var options = { returnOriginal: true };
+
+            SubModel.findOneAndUpdate(filter, update, options, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it replaces a single document via findOneAndReplace', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var filter = { name: 'Ren' };
+            var doc = { isCool: true };
+
+            SubModel.findOneAndReplace(filter, doc, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it replaces a single document via findOneAndReplace (with options)', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var filter = { name: 'Ren' };
+            var doc = { isCool: true };
+            var options = { returnOriginal: true };
+
+            SubModel.findOneAndReplace(filter, doc, options, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it replaces one document and returns the result', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var filter = { name: 'Ren' };
+            var doc = { isCool: true };
+
+            SubModel.replaceOne(filter, doc, function (err, count) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(1);
+
+                done(err);
+            });
+        });
+    });
+
+
+    lab.test('it replaces one document and returns the result (with options)', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var filter = { name: 'Ren' };
+            var doc = { isCool: true };
+            var options = { upsert: true };
+
+            SubModel.replaceOne(filter, doc, options, function (err, count) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(1);
+
+                done(err);
+            });
+        });
+    });
+
+
+    lab.test('it returns an error when replaceOne fails', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var realCollection = BaseModel.db.collection;
+            BaseModel.db.collection = function () {
+
+                return {
+                    replaceOne: function (filter, doc, options, callback) {
+
+                        callback(new Error('Whoops!'));
+                    }
+                };
+            };
+
+            var filter = { name: 'Ren' };
+            var doc = { isCool: true };
+
+            SubModel.replaceOne(filter, doc, function (err, count) {
+
+                Code.expect(err).to.exist();
+                Code.expect(count).to.not.exist();
+
+                BaseModel.db.collection = realCollection;
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it deletes a document via findOneAndDelete', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var filter = { name: 'Ren' };
+
+            SubModel.findOneAndDelete(filter, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it deletes a document via findByIdAndDelete', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var id = results.setup[0]._id;
+
+            SubModel.findByIdAndDelete(id, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it deletes a single document via findByIdAndDelete (with options)', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDoc = { name: 'Ren' };
+
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            var id = results.setup[0]._id;
+            var options = {
+                projection: {
+                    name: 1
+                }
+            };
+
+            SubModel.findByIdAndDelete(id, options, function (err, result) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(result).to.be.an.object();
+                Code.expect(result).to.be.an.instanceOf(SubModel);
+
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it returns an error when id casting fails during findByIdAndDelete', function (done) {
+
+        SubModel.findByIdAndDelete('NOTVALIDOBJECTID', function (err, result) {
 
             Code.expect(err).to.exist();
             done();
@@ -631,15 +1232,125 @@ lab.experiment('BaseModel Proxied Methods', function () {
     });
 
 
-    lab.test('it removes documents via query', function (done) {
+    lab.test('it deletes one document via deleteOne', function (done) {
 
-        SubModel.remove({}, function (err, result) {
+        Async.auto({
+            setup: function (cb) {
 
-            Code.expect(err).to.not.exist();
-            Code.expect(result).to.be.a.number();
-            Code.expect(result).to.equal(2);
+                var testDoc = { name: 'Ren' };
 
-            done();
+                SubModel.insertOne(testDoc, cb);
+            }
+        }, function (err, results) {
+
+            SubModel.deleteOne({}, function (err, count) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(1);
+
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it returns an error when deleteOne fails', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' }
+                ];
+
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, function (err, results) {
+
+            var realCollection = BaseModel.db.collection;
+            BaseModel.db.collection = function () {
+
+                return {
+                    deleteOne: function (filter, callback) {
+
+                        callback(new Error('Whoops!'));
+                    }
+                };
+            };
+
+            SubModel.deleteOne({}, function (err, count) {
+
+                Code.expect(err).to.exist();
+                Code.expect(count).to.not.exist();
+
+                BaseModel.db.collection = realCollection;
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it deletes multiple documents and returns the count via deleteMany', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' }
+                ];
+
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, function (err, results) {
+
+            SubModel.deleteMany({}, function (err, count) {
+
+                Code.expect(err).to.not.exist();
+                Code.expect(count).to.be.a.number();
+                Code.expect(count).to.equal(2);
+
+                done();
+            });
+        });
+    });
+
+
+    lab.test('it returns an error when deleteMany fails', function (done) {
+
+        Async.auto({
+            setup: function (cb) {
+
+                var testDocs = [
+                    { name: 'Ren' },
+                    { name: 'Stimpy' }
+                ];
+
+                SubModel.insertMany(testDocs, cb);
+            }
+        }, function (err, results) {
+
+            var realCollection = BaseModel.db.collection;
+            BaseModel.db.collection = function () {
+
+                return {
+                    deleteMany: function (filter, callback) {
+
+                        callback(new Error('Whoops!'));
+                    }
+                };
+            };
+
+            SubModel.deleteMany({}, function (err, count) {
+
+                Code.expect(err).to.exist();
+                Code.expect(count).to.not.exist();
+
+                BaseModel.db.collection = realCollection;
+                done();
+            });
         });
     });
 });

--- a/test/lib/base-model.js
+++ b/test/lib/base-model.js
@@ -151,7 +151,7 @@ lab.experiment('BaseModel Result Factory', function () {
     });
 
 
-    lab.test('it returns an array of instances for a `WriteOpResultObject`', function (done) {
+    lab.test('it returns an array of instances for a `writeOpResult` object', function (done) {
 
         var callback = function (err, results) {
 
@@ -173,6 +173,41 @@ lab.experiment('BaseModel Result Factory', function () {
         };
 
         SubModel.resultFactory(callback, undefined, results);
+    });
+
+
+    lab.test('it returns a instance for a `findOpResult` object', function (done) {
+
+        var callback = function (err, result) {
+
+            Code.expect(err).to.not.exist();
+            Code.expect(result).to.be.an.object();
+            Code.expect(result).to.be.an.instanceOf(SubModel);
+
+            done();
+        };
+        var result = {
+            value: { _id: 'ren', name: 'Ren' }
+        };
+
+        SubModel.resultFactory(callback, undefined, result);
+    });
+
+
+    lab.test('it returns undefined for a `findOpResult` object that missed', function (done) {
+
+        var callback = function (err, result) {
+
+            Code.expect(err).to.not.exist();
+            Code.expect(result).to.not.exist();
+
+            done();
+        };
+        var result = {
+            value: null
+        };
+
+        SubModel.resultFactory(callback, undefined, result);
     });
 
 


### PR DESCRIPTION
There have been quite a few changes to the `mongodb@2.x.x` API. You can find the official migration guide here: http://mongodb.github.io/node-mongodb-native/2.0/tutorials/changes-from-1.0/

 - [x] remove deprecated methods (`findAndModify`, `findAndRemove`, `insert`, `remove`, `update`)
 - [x] add new methods (`insertOne`, `insertMany`, `replaceOne`, `updateOne`, `updateMany`, `deleteOne`, `deleteMany`, `findOneAndUpdate`, `findOneAndDelete`, `findOneAndReplace`)
 - [x] `Config.settings` is now `Config.options` to better match the arguments passed to `MongoClient.connect`
 - [x] rename `findByIdAndRemove` to `findByIdAndDelete` to better match the conventions used in the native drivers.
 - [x] update README docs
 - [x] update other `package.json` dependencies

__PLEASE HELP OUT__: you're encouraged to review and test these changes. Please also review the `README.md` and suggest changes that could make the docs better.