### PR TITLE
Enhancing require process for models

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,15 @@ exports.register = function (server, options, next) {
     var autoIndex = options.hasOwnProperty('autoIndex') ? options.autoIndex : true;
 
     Object.keys(models).forEach(function (key) {
-
-        models[key] = require(Path.join(process.cwd(), models[key]));
+        if (typeof models[key] === 'string') {
+            if (models[key].charAt(0) === '/') {
+                models[key] = require(models[key]);
+            } else if (models[key].charAt(0) === '.') {
+                models[key] = require(Path.join(process.cwd(), models[key]));
+            } else {
+                models[key] = require(models[key]);
+            }
+        }
     });
 
     BaseModel.connect(mongodb, function (err, db) {

--- a/index.js
+++ b/index.js
@@ -6,13 +6,7 @@ var internals = {};
 internals.requireModel = function (models) {
     return function (modelName) {
         if (typeof models[modelName] === 'string') {
-            if (models[modelName].charAt(0) === '/') {
-                models[modelName] = require(models[modelName]);
-            } else if (models[modelName].charAt(0) === '.') {
-                models[modelName] = require(Path.join(process.cwd(), models[modelName]));
-            } else {
-                models[modelName] = require(models[modelName]);
-            }
+            models[modelName] = require(Path.join(process.cwd(), models[modelName]));
         }
     };
 };

--- a/index.js
+++ b/index.js
@@ -1,45 +1,64 @@
 var Path = require('path');
 var BaseModel = require('./lib/base-model');
 
+var internals = {};
+
+internals.requireModel = function (models) {
+    return function (modelName) {
+        if (typeof models[modelName] === 'string') {
+            if (models[modelName].charAt(0) === '/') {
+                models[modelName] = require(models[modelName]);
+            } else if (models[modelName].charAt(0) === '.') {
+                models[modelName] = require(Path.join(process.cwd(), models[modelName]));
+            } else {
+                models[modelName] = require(models[modelName]);
+            }
+        }
+    };
+};
+
+internals.after = function(options, models) {
+    var mongodb = options.mongodb;
+    var autoIndex = options.hasOwnProperty('autoIndex') ? options.autoIndex : true;
+
+    return function (server, next) {
+        BaseModel.connect(mongodb, function (err, db) {
+
+            if (err) {
+                server.log('Error connecting to MongoDB via BaseModel.');
+                return next(err);
+            }
+
+            Object.keys(models).forEach(function (key) {
+
+                if (autoIndex) {
+                    models[key].ensureIndexes();
+                }
+
+                server.expose(key, models[key]);
+            });
+
+            server.expose('BaseModel', BaseModel);
+
+            next();
+        });
+    };
+};
 
 exports.register = function (server, options, next) {
 
     var models = options.models || {};
-    var mongodb = options.mongodb;
-    var autoIndex = options.hasOwnProperty('autoIndex') ? options.autoIndex : true;
 
-    Object.keys(models).forEach(function (key) {
-        if (typeof models[key] === 'string') {
-            if (models[key].charAt(0) === '/') {
-                models[key] = require(models[key]);
-            } else if (models[key].charAt(0) === '.') {
-                models[key] = require(Path.join(process.cwd(), models[key]));
-            } else {
-                models[key] = require(models[key]);
-            }
-        }
+    Object.keys(models).forEach(internals.requireModel(models));
+
+    server.expose('addModel', function (modelName, model) {
+        models[modelName] = model;
+        internals.requireModel(models)(modelName);
     });
 
-    BaseModel.connect(mongodb, function (err, db) {
+    server.after(internals.after(options, models));
 
-        if (err) {
-            server.log('Error connecting to MongoDB via BaseModel.');
-            return next(err);
-        }
-
-        Object.keys(models).forEach(function (key) {
-
-            if (autoIndex) {
-                models[key].ensureIndexes();
-            }
-
-            server.expose(key, models[key]);
-        });
-
-        server.expose('BaseModel', BaseModel);
-
-        next();
-    });
+    next();
 };
 
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var Path = require('path');
 var Hoek = require('hoek');
 var BaseModel = require('./lib/base-model');
+var isAbsolute = require('absolute');
 
 
 exports.register = function (server, options, next) {
@@ -15,7 +16,7 @@ exports.register = function (server, options, next) {
 
         Hoek.assert(typeof modelPath === 'string', 'Model path must be a string');
 
-        if (!Path.isAbsolute(modelPath)) {
+        if (!isAbsolute(modelPath)) {
             modelPath = Path.join(process.cwd(), modelPath);
         }
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "mongodb": "^2.x.x"
   },
   "dependencies": {
+    "absolute": "0.0.1",
     "ampersand-class-extend": "^1.x.x",
     "async": "^0.9.x",
     "hoek": "^2.x.x",

--- a/test/fixtures/dummy-plugin.js
+++ b/test/fixtures/dummy-plugin.js
@@ -1,0 +1,11 @@
+exports.register = function (server, options, next) {
+    var addModel = server.plugins['hapi-mongo-models'].addModel;
+    addModel('Dummy', require('./dummy-model'));
+    next();
+};
+
+exports.register.attributes = {
+    name: 'dummy',
+    version: '0.0.0',
+    dependencies: ['hapi-mongo-models']
+};

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ var ModelsPlugin = Proxyquire('..', {
 
 lab.experiment('Plugin', function () {
 
-    lab.test('it returns and error when the db connection fails', function (done) {
+    lab.test('it returns an error when the db connection fails', function (done) {
 
         var realConnect = stub.BaseModel.connect;
         stub.BaseModel.connect = function (config, callback) {
@@ -26,8 +26,14 @@ lab.experiment('Plugin', function () {
         };
 
         var server = new Hapi.Server();
+
+        var Plugin = {
+            register: ModelsPlugin,
+            options: Config
+        };
+
         server.connection({ port: 0 });
-        server.register(ModelsPlugin, function (err) {
+        server.register(Plugin, function (err) {
 
             server.start(function (err) {
 


### PR DESCRIPTION
I had a few needs related to models:

* I wanted to be able to require them in a more hapi / node idiomatic way, so that my cwd didn't really come into the picture
* I wanted to be able to add them dynamically, so that I can have more decoupled hapi plugins / services in my app

This PR does both those things. It allows specifying a model like so:

```js
models: {
  Kitty: require('./models/kitty')
}
```

Or via an exposed method:

```js
server.plugins['hapi-mongo-models'].addModel('Kitty', require('./models/kitty'));
```

Declaring a dependency on `hapi-mongo-models` in your plugin would allow you to add models prior to the `server.start()`, at which point `hapi-mongo-models` establishes the mongo connection with the full set of models added via initial config and through the server method.

Tests were added, and coverage is still at 100%.

I don't think this constitutes a breaking change since the old relative paths work. It's hard for me to say what start up processes people might have running, but it does mean mongo queries cannot be made on models until after server.start(). 