### PR TITLE
Add support for exclusion of fields in fieldsAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,14 +443,15 @@ See: https://github.com/hapijs/joi#validatevalue-schema-options-callback
 A helper method to create a fields object suitable to use with MongoDB queries
 where:
 
- - `fields` - a string with space separated field names.
+ - `fields` - a string with space separated field names. Fields may be prefixed
+   with `-` to indicate exclusion instead of inclusion.
 
 Returns a MongoDB friendly fields object.
 
 ```js
-Kitten.fieldsAdapter('name email');
+Kitten.fieldsAdapter('name -email');
 
-// { name: true, email: true }
+// { name: true, email: false }
 ```
 
 #### `sortAdapter(sorts)`

--- a/lib/base-model.js
+++ b/lib/base-model.js
@@ -186,7 +186,11 @@ BaseModel.fieldsAdapter = function (fields) {
         fields.forEach((field) => {
 
             if (field) {
-                document[field] = true;
+                const include = field[0] === '-' ? false : true;
+                if (!include) {
+                    field = field.slice(1);
+                }
+                document[field] = include;
             }
         });
 

--- a/test/lib/base-model.js
+++ b/test/lib/base-model.js
@@ -277,10 +277,10 @@ lab.experiment('BaseModel Helpers', () => {
 
     lab.test('it returns expected results for the fields adapter', (done) => {
 
-        const fieldsDoc = BaseModel.fieldsAdapter('one two three');
+        const fieldsDoc = BaseModel.fieldsAdapter('one -two three');
         Code.expect(fieldsDoc).to.be.an.object();
         Code.expect(fieldsDoc.one).to.equal(true);
-        Code.expect(fieldsDoc.two).to.equal(true);
+        Code.expect(fieldsDoc.two).to.equal(false);
         Code.expect(fieldsDoc.three).to.equal(true);
 
         const fieldsDoc2 = BaseModel.fieldsAdapter('');


### PR DESCRIPTION
Small update to the `fieldsAdapter` method -- handle `-` in front of the field in the same fashion as in the `sortAdapter` by excluding fields instead of including them.