### PR TITLE
fix index creating

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const register = async function (server, options) {
             const indexJobs = options.models
                 .map((path) => modelModules[path])
                 .filter((model) => Boolean(model.indexes))
-                .map((model) => model.createIndexes.bind(model, model.indexes));
+                .map((model) => model.createIndexes.call(model, model.indexes));
 
             await Promise.all(indexJobs);
 


### PR DESCRIPTION
Method bind doesn't call mongo-models 'model.createIndexes' method