### PR TITLE
Make options.mongodb.connection.db optional (fix for #84)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ const register = async function (server, options) {
     Hoek.assert(options.mongodb, 'options.mongodb is required');
     Hoek.assert(options.mongodb.connection, 'options.mongodb.connection is required');
     Hoek.assert(options.mongodb.connection.uri, 'options.mongodb.connection.uri is required');
-    Hoek.assert(options.mongodb.connection.db, 'options.mongodb.connection.db is required');
 
     const modelModules = options.models.reduce((accumulator, path) => {
 


### PR DESCRIPTION
Fixes #84 

I've done some quick local testing, and **hapi-mongo-models** db connection works as expected when `options.mongodb.connection.uri` contains the db name and `options.mongodb.connection.db` is omitted.